### PR TITLE
Change cypress command 'contains' to 'get'

### DIFF
--- a/cypress/integration/smoketest_homepage_spec.js
+++ b/cypress/integration/smoketest_homepage_spec.js
@@ -3,6 +3,6 @@
 describe("Smoke ping Homepage", function() {
   it("Visits the Home Page", function() {
     cy.visit("http://localhost:8080");
-    cy.contains("h1");
+    cy.get("h1");
   });
 });


### PR DESCRIPTION
This test is currently failing upon forking the repository.

`cy.contains()` gets the DOM element containing the text, since you've passed in `h1`, I am assuming you want to get the `<h1>` selector, not the text content of `h1`. `cy.get()` will get one or more DOM elements by the selector.