### PR TITLE
Fix capitalization of import - fixes crash on Linux

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "./app";
+import App from "./App";
 import "./global.scss";
 
 ReactDOM.render(<App />, document.getElementById("root"));


### PR DESCRIPTION
On Linux, this causes an ENOENT: No file or directory because filenames are case sensitive.